### PR TITLE
bumped maps sdk to stable 5.2.0

### DIFF
--- a/StoreLocator/app/build.gradle
+++ b/StoreLocator/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
 
     // Mapbox Maps SDK dependency
-    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.2.0-beta.5@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.2.0@aar') {
         transitive = true
     }
 


### PR DESCRIPTION
Part of the android maps sdk 5.2.0 release

Don't merge this pr until the 5.2.0 release by @Guardiola31337  actually happens

[https://github.com/mapbox/mapbox-gl-native/issues/10486#event-1347400074](https://github.com/mapbox/mapbox-gl-native/issues/10486#event-1347400074)