### PR TITLE
Fixing NDK directory issue in local.properties

### DIFF
--- a/StoreLocator/build.gradle
+++ b/StoreLocator/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/StoreLocator/gradle/wrapper/gradle-wrapper.properties
+++ b/StoreLocator/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 22 13:28:54 PST 2019
+#Tue Feb 12 14:33:39 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/StoreLocator/local.properties
+++ b/StoreLocator/local.properties
@@ -1,9 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Tue Apr 24 15:00:39 PDT 2018
-ndk.dir=/Users/langstonsmith/Library/Android/sdk/ndk-bundle
-sdk.dir=/Users/langstonsmith/Library/Android/sdk


### PR DESCRIPTION
CI was failing because of an NDK path issue. This pr fixes this so that `master` can build.

<img width="1246" alt="screen shot 2019-02-12 at 2 36 46 pm" src="https://user-images.githubusercontent.com/4394910/52672786-a6078a80-2ed3-11e9-97fa-f7e8ac03aac7.png">
