### PR TITLE
Bumped Java SDK services and turf dependencies to 4.8.0

### DIFF
--- a/StoreLocator/app/build.gradle
+++ b/StoreLocator/app/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:7.3.0'
 
     // Mapbox Services SDK dependency to retrieve direction routes
-    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:4.5.0'
-    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-turf:4.6.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:4.8.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-turf:4.8.0'
 
     // Mapbox Buildings Plugin for showing and customizing 3D building extrusions
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v7:0.5.0'


### PR DESCRIPTION
This pr bumps the Java SDK's services and turf dependencies to the latest stable version, which is 4.8.0